### PR TITLE
Add siteId param to $templateEntry fetch

### DIFF
--- a/src/elements/processors/EntryProcessor.php
+++ b/src/elements/processors/EntryProcessor.php
@@ -77,7 +77,7 @@ class EntryProcessor extends AbstractElementTypeProcessor
      */
     public static function getMockElement($elementIds = [], $params = []): Element
     {
-        $templateEntry = Craft::$app->entries->getEntryById($elementIds[0]);
+        $templateEntry = Craft::$app->entries->getEntryById($elementIds[0], $params['siteId']);
         /** @var Entry $entry */
         $entry = Craft::createObject(self::getType(), $params);
         $entry->typeId = $templateEntry->typeId;


### PR DESCRIPTION
Fixes a bug that prevents bulk editing in multisite environments, as the $template Entry was not bering passed a `siteId` parameter and was therefore not finding the entry.