### PR TITLE
FR: Make strategy names translatable

### DIFF
--- a/src/fields/strategies/Add.php
+++ b/src/fields/strategies/Add.php
@@ -2,6 +2,7 @@
 
 namespace venveo\bulkedit\fields\strategies;
 
+use Craft;
 use venveo\bulkedit\base\FieldStrategyInterface;
 
 class Add implements FieldStrategyInterface

--- a/src/fields/strategies/Add.php
+++ b/src/fields/strategies/Add.php
@@ -9,6 +9,6 @@ class Add implements FieldStrategyInterface
 {
     public static function displayName(): string
     {
-        return Craft::t('bulk-edit', 'Add');
+        return Craft::t('venveo-bulk-edit', 'Add');
     }
 }

--- a/src/fields/strategies/Add.php
+++ b/src/fields/strategies/Add.php
@@ -8,6 +8,6 @@ class Add implements FieldStrategyInterface
 {
     public static function displayName(): string
     {
-        return 'Add';
+        return Craft::t('bulk-edit', 'Add');
     }
 }

--- a/src/fields/strategies/Divide.php
+++ b/src/fields/strategies/Divide.php
@@ -2,12 +2,13 @@
 
 namespace venveo\bulkedit\fields\strategies;
 
+use Craft;
 use venveo\bulkedit\base\FieldStrategyInterface;
 
 class Divide implements FieldStrategyInterface
 {
     public static function displayName(): string
     {
-        return 'Divide';
+        return Craft::t('bulk-edit', 'Divide');
     }
 }

--- a/src/fields/strategies/Divide.php
+++ b/src/fields/strategies/Divide.php
@@ -9,6 +9,6 @@ class Divide implements FieldStrategyInterface
 {
     public static function displayName(): string
     {
-        return Craft::t('bulk-edit', 'Divide');
+        return Craft::t('venveo-bulk-edit', 'Divide');
     }
 }

--- a/src/fields/strategies/Merge.php
+++ b/src/fields/strategies/Merge.php
@@ -2,12 +2,13 @@
 
 namespace venveo\bulkedit\fields\strategies;
 
+use Craft;
 use venveo\bulkedit\base\FieldStrategyInterface;
 
 class Merge implements FieldStrategyInterface
 {
     public static function displayName(): string
     {
-        return 'Merge';
+        return Craft::t('bulk-edit', 'Merge');
     }
 }

--- a/src/fields/strategies/Merge.php
+++ b/src/fields/strategies/Merge.php
@@ -9,6 +9,6 @@ class Merge implements FieldStrategyInterface
 {
     public static function displayName(): string
     {
-        return Craft::t('bulk-edit', 'Merge');
+        return Craft::t('venveo-bulk-edit', 'Merge');
     }
 }

--- a/src/fields/strategies/Multiply.php
+++ b/src/fields/strategies/Multiply.php
@@ -2,12 +2,13 @@
 
 namespace venveo\bulkedit\fields\strategies;
 
+use Craft;
 use venveo\bulkedit\base\FieldStrategyInterface;
 
 class Multiply implements FieldStrategyInterface
 {
     public static function displayName(): string
     {
-        return 'Multiply';
+        return Craft::t('bulk-edit', 'Multiply');
     }
 }

--- a/src/fields/strategies/Multiply.php
+++ b/src/fields/strategies/Multiply.php
@@ -9,6 +9,6 @@ class Multiply implements FieldStrategyInterface
 {
     public static function displayName(): string
     {
-        return Craft::t('bulk-edit', 'Multiply');
+        return Craft::t('venveo-bulk-edit', 'Multiply');
     }
 }

--- a/src/fields/strategies/Replace.php
+++ b/src/fields/strategies/Replace.php
@@ -9,6 +9,6 @@ class Replace implements FieldStrategyInterface
 {
     public static function displayName(): string
     {
-        return Craft::t('bulk-edit', 'Replace');
+        return Craft::t('venveo-bulk-edit', 'Replace');
     }
 }

--- a/src/fields/strategies/Replace.php
+++ b/src/fields/strategies/Replace.php
@@ -2,12 +2,13 @@
 
 namespace venveo\bulkedit\fields\strategies;
 
+use Craft;
 use venveo\bulkedit\base\FieldStrategyInterface;
 
 class Replace implements FieldStrategyInterface
 {
     public static function displayName(): string
     {
-        return 'Replace';
+        return Craft::t('bulk-edit', 'Replace');
     }
 }

--- a/src/fields/strategies/Subtract.php
+++ b/src/fields/strategies/Subtract.php
@@ -9,6 +9,6 @@ class Subtract implements FieldStrategyInterface
 {
     public static function displayName(): string
     {
-        return Craft::t('bulk-edit', 'Subtract');
+        return Craft::t('venveo-bulk-edit', 'Subtract');
     }
 }

--- a/src/fields/strategies/Subtract.php
+++ b/src/fields/strategies/Subtract.php
@@ -2,12 +2,13 @@
 
 namespace venveo\bulkedit\fields\strategies;
 
+use Craft;
 use venveo\bulkedit\base\FieldStrategyInterface;
 
 class Subtract implements FieldStrategyInterface
 {
     public static function displayName(): string
     {
-        return 'Subtract';
+        return Craft::t('bulk-edit', 'Subtract');
     }
 }


### PR DESCRIPTION
For our clients, having Dutch strategy display names would make working with Bulk Edit easier. With this pull request, we would be able to translate/rename the strategy names.