### PR TITLE
RelationalFieldProcessor fix for single-valued relations.

### DIFF
--- a/src/fields/processors/RelationFieldProcessor.php
+++ b/src/fields/processors/RelationFieldProcessor.php
@@ -46,7 +46,7 @@ class RelationFieldProcessor extends AbstractFieldProcessor
         $originalValue = $element->getFieldValue($field->handle);
         $fieldHandle = $field->handle;
         $ids = $originalValue->ids();
-        $ids = array_merge($ids, $value);
+        $ids = array_merge($ids, is_array($value) ? $value : [$value]);
 
         $element->setFieldValue($fieldHandle, $ids);
     }


### PR DESCRIPTION
Added a quick fix that just checks if the value is an array at first. If it is not, it wraps the value in an array.
I haven't found any regressions.

Fixes #51 