### PR TITLE
make fields layout aware -> always grab fields from the correct layou…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Bulk Edit Changelog
 
+## Unreleased
+
+### added
+
+- added new param `layoutId` to `venveo\bulkedit\models\FieldConfig` to store the fields layout id 
+- added `layoutIds` hidden field in `templates/elementactions/BulkEdit/_fields.twig`
+- added a regex to pass the new layoutId param in `assetbundles/bulkeditelementaction/dist/js/BulkEditModal.js`
+
+### changed
+
+- always fields from layout and not from global fields
+
 ## 5.0.0-beta.1 - 2024-09-26
 
 > [!IMPORTANT]

--- a/src/assetbundles/bulkeditelementaction/dist/js/BulkEditModal.js
+++ b/src/assetbundles/bulkeditelementaction/dist/js/BulkEditModal.js
@@ -202,6 +202,12 @@ Craft.BulkEditModal = Garnish.Modal.extend({
         _getFieldConfig: function(formData) {
             var formDataObject = {};
             const fieldHandleRegex = /fields\[(\d+)\]\[(.+)\]/;
+
+            // with Craft 5 ability to rename fields + relabel fields
+            // we need to add the field layout id and grab the field from the layout
+            // not from global fields -> additional regex to grab the layout ids
+            const layoutIdRegex = /fields\[(\d+)\]\[layoutIds\]\[\]/;
+
             formData.forEach((value, key) => {
                 const fieldHandle = key.match(fieldHandleRegex)[1]
                 const propertyName = key.match(fieldHandleRegex)[2]
@@ -210,7 +216,19 @@ Craft.BulkEditModal = Garnish.Modal.extend({
                         id: fieldHandle
                     }
                 }
-                formDataObject[fieldHandle][propertyName] = value
+
+                // check if it's the nested layoutIds array
+                const layoutIdMatch = key.match(layoutIdRegex);
+                if(layoutIdMatch && layoutIdMatch.length >= 1){
+                    if(!formDataObject[fieldHandle].hasOwnProperty('layoutIds')) {
+                        formDataObject[fieldHandle]['layoutIds'] = []
+                    }
+
+                    formDataObject[fieldHandle]['layoutIds'].push(Number.parseInt(value));
+                } else {
+                    formDataObject[fieldHandle][propertyName] = value
+                }
+
             });
             return formDataObject
         },

--- a/src/controllers/BulkEditController.php
+++ b/src/controllers/BulkEditController.php
@@ -19,7 +19,6 @@ use craft\helpers\StringHelper;
 use craft\models\FieldLayout;
 use craft\models\FieldLayoutTab;
 use craft\models\Site;
-use craft\records\Field;
 use craft\web\Response;
 use Exception;
 use Twig\Error\LoaderError;
@@ -118,14 +117,43 @@ class BulkEditController extends ElementIndexesController
 
         $fields = $this->request->getRequiredParam('fieldConfig');
         $namespace = $this->request->getRequiredParam('namespace');
-        $enabledFields = array_filter($fields, fn($field) => $field['enabled']);
-        $fields = Field::findAll(array_keys($enabledFields));
+
+        $fieldsService = Craft::$app->getFields();
         $fieldModels = [];
-        /** @var Field $field */
+
         foreach ($fields as $field) {
-            $fieldModel = Craft::$app->fields->getFieldById($field->id);
-            if ($fieldModel && Plugin::$plugin->bulkEdit->isFieldSupported($fieldModel)) {
-                $fieldModels[] = $fieldModel;
+            if(!$field['enabled']) {
+                continue;
+            }
+
+            $fieldId = (int)$field['id'];
+            $layoutIds = $field['layoutIds'];
+            foreach ($layoutIds as $layoutId) {
+                $layout = $fieldsService->getLayoutById($layoutId);
+                if(!$layout){
+                    continue;
+                }
+
+                $layoutField = $layout->getFieldById($fieldId);
+                if(!$layoutField || !Plugin::$plugin->bulkEdit->isFieldSupported($layoutField)){
+                    continue;
+                }
+                // due to current restrictions of field namespaces we cannot add the very same field with the same handle twice
+                // otherwise we need to render 2 separate field layouts and pass two different namespace params.
+                //
+                // I tried to include another layout but failed unfortunately (in a reasonable amount of time)
+                // so as of now this only works for one field for all field layouts
+                //
+                // This will currently break in case users select two elements with a different layout where one
+                // field is instance of A and another field with the very same handle is instance of B while the two
+                // field types are incompatible to each other
+                // the only way to solve this is to render two separate fields and separate their handles
+                // (eg include the layout ID into the handle and regex it)
+                /** @see \venveo\bulkedit\services\BulkEdit::processElementWithContext */
+                if(isset($fieldModels[$layoutField->handle])){
+                    continue;
+                }
+                $fieldModels[$layoutField->handle] = $layoutField;
             }
         }
 
@@ -189,23 +217,44 @@ class BulkEditController extends ElementIndexesController
 
         $fieldConfigData = $this->request->getRequiredParam('fieldConfig');
 
+        $fieldService = Craft::$app->getFields();
         $fieldConfigs = [];
         foreach ($fieldConfigData as $fieldConfigDatum) {
             if (!$fieldConfigDatum['enabled']) {
                 continue;
             }
+
             $fieldConfig = new FieldConfig();
             $fieldConfig->strategy = $fieldConfigDatum['strategy'];
             $fieldConfig->type = $fieldConfigDatum['type'];
-            if ($fieldConfig->type === FieldType::CustomField) {
-                $fieldConfig->fieldId = (int)$fieldConfigDatum['id'];
-                $fieldConfig->handle = Craft::$app->fields->getFieldById($fieldConfig->fieldId)->handle;
-                $fieldConfig->serializedValue = Json::encode($fieldValues[$fieldConfig->handle]);
-            }
+            if ($fieldConfig->type !== FieldType::CustomField) {
             if ($fieldConfig->validate()) {
                 $fieldConfigs[] = $fieldConfig;
-            } else {
+                    continue;
+                }
                 throw new \Exception('Failed to validate field configuration: ' . Json::encode($fieldConfig));
+            }
+
+            $layoutIds = $fieldConfigDatum['layoutIds'];
+            foreach ($layoutIds as $layoutId) {
+                $fieldConfigForLayout = clone $fieldConfig;
+
+                $fieldConfigForLayout->fieldId = (int)$fieldConfigDatum['id'];
+
+                $layout = $fieldService->getLayoutById($layoutId);
+                if(!$layout){
+                    continue;
+                }
+
+                $field = $layout->getFieldById($fieldConfigDatum['id']);
+                if(!$field){
+                    continue;
+                }
+
+                $fieldConfigForLayout->handle = $field->handle;
+                $fieldConfigForLayout->layoutId = $layoutId;
+                $fieldConfigForLayout->serializedValue = Json::encode($fieldValues[$fieldConfigForLayout->handle]);
+                $fieldConfigs[] = $fieldConfigForLayout;
             }
         }
 

--- a/src/models/FieldConfig.php
+++ b/src/models/FieldConfig.php
@@ -13,6 +13,9 @@ class FieldConfig extends Model
     /** @var int|null If we have a field ID, store it here */
     public ?int $fieldId = null;
 
+    /** @var int|null $layoutId we need to store the layout of the field for the correct handle later */
+    public ?int $layoutId = null;
+
     /**
      * @var string|null
      * @see \venveo\bulkedit\enums\FieldType

--- a/src/services/BulkEdit.php
+++ b/src/services/BulkEdit.php
@@ -198,10 +198,17 @@ class BulkEdit extends Component
         // We'll process the entire element in a transaction to help avoid problems
         $transaction = Craft::$app->getDb()->beginTransaction();
         $fieldConfigs = $contextModel->fieldConfigs;
+        $fieldService = Craft::$app->getFields();
         try {
             foreach ($fieldConfigs as $fieldConfig) {
                 $newValue = Json::decode($fieldConfig->serializedValue);
-                $field = Craft::$app->fields->getFieldById($fieldConfig->fieldId);
+
+                // grab the field layout instance in the layout
+                if($fieldConfig->layoutId && $fieldConfig->handle){
+                    $field = $fieldService->getLayoutById($fieldConfig->layoutId)?->getFieldByHandle($fieldConfig->handle);
+                } else {
+                    $field = Craft::$app->fields->getFieldById($fieldConfig->fieldId);
+                }
                 $processor = $this->getFieldProcessor($field, $fieldConfig->strategy);
                 $processor::processElementField($element, $field, $fieldConfig->strategy, $newValue);
                 Craft::info('Saved history item', __METHOD__);

--- a/src/templates/elementactions/BulkEdit/_fields.twig
+++ b/src/templates/elementactions/BulkEdit/_fields.twig
@@ -47,6 +47,9 @@
                         {% set fieldUnsupported = true %}
                     {% endif %}
                     {{ hiddenInput('fields['~field.id~'][type]', 'CustomField') }}
+                    {% for layout in fieldWrapper.layouts %}
+                        {{ hiddenInput('fields['~field.id~'][layoutIds][]', layout.id) }}
+                    {% endfor %}
                     <tr>
                         <td>
             <span>


### PR DESCRIPTION
make fields layout aware -> always grab fields from the correct layout, pass the layoutId all the way through the process

fixes #61

## Limitations

This PR will only make it "kinda" work. With the ability rename fields in different layouts users can have a section with two entry types where there is a field in layout A with instance of Number and another field with the very same handle with type `craft\fields\Entries` in layout B.   
Since we can only render one field layout (because we can currently only pass one single namespace param easily) there is no way to have the same handle twice. 

We would need a HTML form with
```html
<!-- layout 1 text field headline -->
<input type="text" name="fields[headline]" value="foo">

<!-- layout 2 headline is now an Entries field -->
<input type="text" name="fields[headline][]" value="1">
<input type="text" name="fields[headline][]" value="2">
``` 
in the very same form which is impossible. One work around would be to render a different form for each field layout, the other one is to change the handle and include the layout id by Crafts namespace tricks. However both methods require a huge amount of refactoring and I didn't want to modify way to much without asking.